### PR TITLE
Create config variables for Service Provider model

### DIFF
--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -69,6 +69,6 @@ return [
     'guards' => ['web'],
 
     // Define the model used to store service provider configurations (if applicable)
-    'config_model_usage' => false,
-    'config_model' => \CodeGreenCreative\SamlIdp\Models\ServiceProvider::class
+    'service_provider_model_usage' => false,
+    'service_provider_model' => \CodeGreenCreative\SamlIdp\Models\ServiceProvider::class
 ];

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -67,4 +67,8 @@ return [
 
     // List of guards saml idp will catch Authenticated, Login and Logout events
     'guards' => ['web'],
+
+    // Define the model used to store service provider configurations (if applicable)
+    'config_model_usage' => false,
+    'config_model' => \CodeGreenCreative\SamlIdp\Src\Models\ServiceProvider::class
 ];

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -70,5 +70,5 @@ return [
 
     // Define the model used to store service provider configurations (if applicable)
     'config_model_usage' => false,
-    'config_model' => \CodeGreenCreative\SamlIdp\Src\Models\ServiceProvider::class
+    'config_model' => \CodeGreenCreative\SamlIdp\Models\ServiceProvider::class
 ];


### PR DESCRIPTION
Added a config variable that determine whether the database is used to obtain configuration variables when preforming SSO

Added another config variable that specifies what model is used to hold sp configurations