### PR TITLE
SamlSso - Config only behavior test case

### DIFF
--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace CodeGreenCreative\SamlIdp\Tests;
+
+use CodeGreenCreative\SamlIdp\Jobs\SamlSso;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+
+class SamlSsoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var string
+     */
+    public string $certificate = '';
+
+    /**
+     * @var string
+     */
+    public string $key = '';
+
+    /**
+     * @var string
+     */
+    public string $fakeACS = 'https://test-example.com';
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createFakeCertificate();
+
+        config([
+            'samlidp.email_field' => 'email',
+            'samlidp.cert' => $this->certificate,
+            'samlidp.key' => $this->key,
+        ]);
+
+        // This job is dispatched in the middle of a request-response cycle - so we need to create the request that it's
+        // expecting with an authenticated user
+        $user = new User();
+        $user->email = 'fake_email'; // This email HAS to be set for the saml assertion to be created
+        $this->actingAs($user);
+
+        $request = Request::create('route-doesnt-matter-here', 'POST', ['SAMLRequest'=> $this->createFakeSamlRequest()]);
+        $this->swap('request', $request);
+    }
+
+    private function createFakeCertificate(): void
+    {
+        // create new private and public key
+        $res = openssl_pkey_new();
+
+        // generate a certificate signing request
+        $csr = openssl_csr_new([uniqid()], $res);
+
+        // sign CSR
+        $signing = openssl_csr_sign($csr, null, $res, 365, ['digest_alg'=>'sha256']);
+
+        // export the certificate and private key to string
+        openssl_x509_export($signing, $this->certificate);
+        openssl_pkey_export($res, $this->key);
+    }
+
+    private function createFakeSamlRequest(): string
+    {
+        $fakeSamlRequestXml = '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+ID="ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
+Version="2.0"
+ProviderName="SP test"
+IssueInstant="2014-07-16T23:52:45Z"
+Destination="http://idp.example.com/SSOService.php"
+ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+AssertionConsumerServiceURL="'.$this->fakeACS.'">
+<saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>
+<samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+AllowCreate="true" />
+<samlp:RequestedAuthnContext Comparison="exact">
+<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+</samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>';
+
+        // gzip inflate
+        $gzSamlRequest = gzdeflate($fakeSamlRequestXml);
+
+        // base64 encode
+        return base64_encode($gzSamlRequest);
+    }
+
+
+    // The following test case is to ensure that when the 'service_provider_model_usage' config variable is not set,
+    // the SamlSso job will run as normal and use the configuration data provided in the config to create a response.
+    #[Test]
+    public function use_config_variables_to_create_response_when_database_access_config_variable_is_not_set(): void
+    {
+        // Arrange
+        $fakeSPConfig = [
+             'destination' => 'https://faketest.com',
+             'logout' => 'https://anotherfaketest.com',
+             'certificate' => '',
+             'query_params' => false,
+             'encrypt_assertion' => false
+        ];
+
+        $encodedAcsUrl = base64_encode($this->fakeACS);
+        config([
+            'samlidp.sp' => [
+                $encodedAcsUrl => $fakeSPConfig
+            ]
+        ]);
+
+        // Act
+        $samlResponse = (new SamlSso())->handle();
+
+        // Assert
+        $this->assertNotNull($samlResponse);
+
+        $expectedFormTag = '<form method="post" action="' . $fakeSPConfig['destination'] .'">';
+        $this->assertTrue(str_contains($samlResponse, $expectedFormTag));
+    }
+}

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -65,23 +65,25 @@ class SamlSsoTest extends TestCase
 
     private function createFakeSamlRequest(): string
     {
-        $fakeSamlRequestXml = '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-ID="ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
-Version="2.0"
-ProviderName="SP test"
-IssueInstant="2014-07-16T23:52:45Z"
-Destination="http://idp.example.com/SSOService.php"
-ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-AssertionConsumerServiceURL="'.$this->fakeACS.'">
-<saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>
-<samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-AllowCreate="true" />
-<samlp:RequestedAuthnContext Comparison="exact">
-<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
-</samlp:RequestedAuthnContext>
-</samlp:AuthnRequest>';
-
+        $fakeSamlRequestXml = <<<XML
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+         xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+         ID="ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
+         Version="2.0"
+         ProviderName="SP test"
+         IssueInstant="2014-07-16T23:52:45Z"
+         Destination="http://idp.example.com/SSOService.php"
+         ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+         AssertionConsumerServiceURL="$this->fakeACS">
+         <saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>
+         <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+         AllowCreate="true" />
+         <samlp:RequestedAuthnContext Comparison="exact">
+         <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+         </samlp:RequestedAuthnContext>
+         </samlp:AuthnRequest>
+XML;
+        
         // gzip inflate
         $gzSamlRequest = gzdeflate($fakeSamlRequestXml);
 
@@ -93,11 +95,11 @@ AllowCreate="true" />
     // The following test case is to ensure that when the 'service_provider_model_usage' config variable is not set,
     // the SamlSso job will run as normal and use the configuration data provided in the config to create a response.
     #[Test]
-    public function use_config_variables_to_create_response_when_database_access_config_variable_is_not_set(): void
+    public function create_saml_response_using_samlidp_config(): void
     {
         // Arrange
         $fakeSPConfig = [
-             'destination' => 'https://faketest.com',
+             'destination' => $this->fakeACS,
              'logout' => 'https://anotherfaketest.com',
              'certificate' => '',
              'query_params' => false,

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -104,6 +104,8 @@ AllowCreate="true" />
              'encrypt_assertion' => false
         ];
 
+        // We HAVE to keep the exact format given in the config, i.e (encoded ACS URL => SP configuration)
+        // Otherwise the SamlSso job will not be able to find the correct service provider configuration
         $encodedAcsUrl = base64_encode($this->fakeACS);
         config([
             'samlidp.sp' => [

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -4,14 +4,11 @@ namespace CodeGreenCreative\SamlIdp\Tests;
 
 use CodeGreenCreative\SamlIdp\Jobs\SamlSso;
 use Illuminate\Foundation\Auth\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\Test;
 
 class SamlSsoTest extends TestCase
 {
-    use RefreshDatabase;
-
     /**
      * @var string
      */

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -83,7 +83,7 @@ class SamlSsoTest extends TestCase
          </samlp:RequestedAuthnContext>
          </samlp:AuthnRequest>
 XML;
-        
+
         // gzip inflate
         $gzSamlRequest = gzdeflate($fakeSamlRequestXml);
 
@@ -94,7 +94,7 @@ XML;
 
     // The following test case is to ensure that when the 'service_provider_model_usage' config variable is not set,
     // the SamlSso job will run as normal and use the configuration data provided in the config to create a response.
-    #[Test]
+    /** @test */
     public function create_saml_response_using_samlidp_config(): void
     {
         // Arrange


### PR DESCRIPTION
Created a base test case to ensure SamlSso job can use service provider (sp) config variables and create the expected saml response to send to the sp.