### PR TITLE
Use model and database access variables in samlidp config to build Saml response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4",
-        "orchestra/testbench": "^8.15"
+        "orchestra/testbench": "^8.15",
+        "laravel/legacy-factories": "^1.0.4"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-4": {
             "CodeGreenCreative\\SamlIdp\\": "src/",
-            "CodeGreenCreative\\SamlIdp\\Tests\\": "tests/"
+            "CodeGreenCreative\\SamlIdp\\Tests\\": "tests/",
+            "CodeGreenCreative\\SamlIdp\\Database\\Factories\\": "database/factories/"
         }
     },
     "extra": {

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -2,11 +2,14 @@
 
 namespace CodeGreenCreative\SamlIdp\Database\Factories;
 
+use CodeGreenCreative\SamlIdp\Models\ServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class ServiceProviderFactory extends Factory
 {
+    protected $model = ServiceProvider::class;
+
     /**
      * Define the model's default state.
      *

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -1,13 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace Database\Factories;
+namespace CodeGreenCreative\SamlIdp\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
-/**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\CodeGreenCreative\SamlIdp\Models\ServiceProvider>
- */
 class ServiceProviderFactory extends Factory
 {
     /**
@@ -15,7 +12,7 @@ class ServiceProviderFactory extends Factory
      *
      * @return array<string, mixed>
      */
-    public function definition()
+    public function definition(): array
     {
         return [
             'destination_url' => $this->faker->url,

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -3,28 +3,17 @@
 namespace CodeGreenCreative\SamlIdp\Database\Factories;
 
 use CodeGreenCreative\SamlIdp\Models\ServiceProvider;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
-class ServiceProviderFactory extends Factory
-{
-    protected $model = ServiceProvider::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition(): array
-    {
-        return [
-            'destination_url' => $this->faker->url,
-            'logout_url' => $this->faker->url,
-            'certificate' => $this->faker->text(100),
-            'block_encryption_algorithm' => XMLSecurityKey::AES128_CBC,
-            'key_transport_encryption' => XMLSecurityKey::RSA_1_5,
-            'query_parameters' => false,
-            'encrypt_assertion' => false,
-        ];
-    }
-}
+$factory->define(ServiceProvider::class, function () {
+    return [
+        'destination_url' => $this->faker->url,
+        'logout_url' => $this->faker->url,
+        'certificate' => $this->faker->text(100),
+        'block_encryption_algorithm' => XMLSecurityKey::AES128_CBC,
+        'key_transport_encryption' => XMLSecurityKey::RSA_1_5,
+        'query_parameters' => false,
+        'encrypt_assertion' => false,
+    ];
+});

--- a/src/Models/ServiceProvider.php
+++ b/src/Models/ServiceProvider.php
@@ -2,14 +2,10 @@
 
 namespace CodeGreenCreative\SamlIdp\Models;
 
-use CodeGreenCreative\SamlIdp\Database\Factories\ServiceProviderFactory;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ServiceProvider extends Model
 {
-    use HasFactory;
-
     protected $fillable = [
         'destination_url',
         'logout_url',
@@ -19,9 +15,4 @@ class ServiceProvider extends Model
         'query_parameters',
         'encrypt_assertion',
     ];
-
-    protected static function newFactory(): ServiceProviderFactory
-    {
-        return ServiceProviderFactory::new();
-    }
 }

--- a/src/Models/ServiceProvider.php
+++ b/src/Models/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace CodeGreenCreative\SamlIdp\Models;
 
+use CodeGreenCreative\SamlIdp\Database\Factories\ServiceProviderFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -18,4 +19,9 @@ class ServiceProvider extends Model
         'query_parameters',
         'encrypt_assertion',
     ];
+
+    protected static function newFactory(): ServiceProviderFactory
+    {
+        return ServiceProviderFactory::new();
+    }
 }

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -160,6 +160,38 @@ XML;
     }
 
     /** @test */
+    public function do_not_access_database_if_service_provider_model_usage_variable_is_false(): void
+    {
+        // Arrange
+        config([
+            'samlidp.service_provider_model_usage' => false,
+        ]);
+
+        $fakeSPConfig = [
+            'destination' => $this->fakeACS,
+            'logout' => 'https://anotherfaketest.com',
+            'certificate' => '',
+            'query_params' => false,
+            'encrypt_assertion' => false
+        ];
+        
+        $encodedAcsUrl = base64_encode($this->fakeACS);
+        config([
+            'samlidp.sp' => [
+                $encodedAcsUrl => $fakeSPConfig
+            ]
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        // Act
+        $samlResponse = (new SamlSso())->handle();
+
+        // Assert
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    /** @test */
     public function create_response_using_service_provider_model_when_database_access_is_configured(): void
     {
         // Arrange

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -174,7 +174,7 @@ XML;
             'query_params' => false,
             'encrypt_assertion' => false
         ];
-        
+
         $encodedAcsUrl = base64_encode($this->fakeACS);
         config([
             'samlidp.sp' => [
@@ -199,8 +199,9 @@ XML;
             'samlidp.service_provider_model_usage' => true,
             'samlidp.service_provider_model' => ServiceProvider::class
         ]);
-        $serviceProvider = ServiceProvider::factory()->create([
-            'destination_url' => $this->fakeACS // This field HAS to match the ACS URL in the SAML request
+
+        $serviceProvider = factory(ServiceProvider::class)->create([
+            'destination_url' => $this->fakeACS
         ]);
 
         // Act
@@ -233,8 +234,8 @@ XML;
             ]
         ]);
 
-        $serviceProvider = ServiceProvider::factory()->create([
-            'destination_url' => $this->fakeACS // This field HAS to match the ACS URL in the SAML request
+        $serviceProvider = factory(ServiceProvider::class)->create([
+            'destination_url' => $this->fakeACS
         ]);
 
         // Act

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,12 @@ use \Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withFactories(__DIR__ . '/../database/factories');
+    }
     /**
      * Get package providers.
      *
@@ -40,5 +46,15 @@ abstract class TestCase extends OrchestraTestCase
             'prefix' => '',
             'schema' => 'public',
         ]);
+    }
+
+    /**
+     * Define database migrations.
+     *
+     * @return void
+     */
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,43 @@
 
 namespace CodeGreenCreative\SamlIdp\Tests;
 
+use CodeGreenCreative\SamlIdp\LaravelSamlIdpServiceProvider;
 use \Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
-    //
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array<int, class-string<\Illuminate\Support\ServiceProvider>>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            LaravelSamlIdpServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'pgsql');
+        $app['config']->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => 'postgres',
+            'port' => '5432',
+            'database' => 'testsuite',
+            'username' => 'testsuite',
+            'password' => 'testsuite',
+            'charset' => 'utf8',
+            'prefix' => '',
+            'schema' => 'public',
+        ]);
+    }
 }


### PR DESCRIPTION
Added logic that allows users use the model that stores service provider configurations to build responses in the SamlSso job

This reduces manual manipulation to the config file